### PR TITLE
INT-4942 sync-be-good

### DIFF
--- a/src/create-or-update-branch.ts
+++ b/src/create-or-update-branch.ts
@@ -161,7 +161,7 @@ interface CreateOrUpdateBranchResult {
   action: string
   base: string
   hasDiffWithBase: boolean
-  wasRebased: boolean
+  wasReset: boolean
   baseCommit: Commit
   headSha: string
   branchCommits: Commit[]
@@ -208,6 +208,31 @@ export async function createOrUpdateBranch(
     }
   }
 
+  // Check if the pull request branch is behind the base branch
+  let wasReset = false;
+  await git.exec(['fetch', baseRemote, base])
+  if (await isBehind(git, base, branch)) {
+    /*
+     * New changes to the base branch are not present in the PR branch.
+     * 
+     * Reset the state of the PR branch back to that of the base branch,
+     * eliminating the commits currently in the PR branch.
+     *
+     * Normally dropping commits is undesirable, but in this specific case, it's
+     * necessary to circumvent any attempt git would make to merge/rebase the
+     * previous PR branch commits onto the newer base branch commits. 
+     * 
+     * Without doing so, this job would almost certainly fail due to conflicts.
+     *
+     * Ultimately, either the dropped commits were a subset of the changes in the
+     * working tree, or their respective changes have since been undone.
+     */
+    core.info(`Pull request branch '${branch}' is behind base branch '${base}'.`)
+    await git.exec(['reset', '--soft', `${baseRemote}/${base}`])
+    core.info(`Reset '${branch}' to '${base}'.`)
+    wasReset = true;
+  }
+
   // Commit any changes
   if (await git.isDirty(true, addPaths)) {
     core.info('Uncommitted changes found. Adding a commit.')
@@ -232,17 +257,6 @@ export async function createOrUpdateBranch(
     }
   }
 
-  // Check if the pull request branch is behind the base branch
-  let wasRebased = false;
-  await git.exec(['fetch', baseRemote, base])
-  if (await isBehind(git, base, branch)) {
-    // Rebase the current branch onto the base branch
-    core.info(`Pull request branch '${branch}' is behind base branch '${base}'.`)
-    await git.exec(['pull', '--rebase', baseRemote, base])
-    core.info(`Rebased '${branch}' commits ontop of '${base}'.`)
-    wasRebased = true;
-  }
-
   hasDiffWithBase = await isAhead(git, base, branch)
 
   // If the base is not specified it is assumed to be the working base.
@@ -264,7 +278,7 @@ export async function createOrUpdateBranch(
     action: action,
     base: base,
     hasDiffWithBase: hasDiffWithBase,
-    wasRebased: wasRebased,
+    wasReset: wasReset,
     baseCommit: baseCommit,
     headSha: headSha,
     branchCommits: branchCommits

--- a/src/create-pull-request.ts
+++ b/src/create-pull-request.ts
@@ -228,7 +228,7 @@ export async function createPullRequest(inputs: Inputs): Promise<void> {
         }
       } else {
         await git.push(
-          result.wasRebased ? [`--force-with-lease`, branchRemoteName, inputs.branch] : []
+          result.wasReset ? [`--force`, branchRemoteName, inputs.branch] : []
         )
       }
       core.endGroup()


### PR DESCRIPTION
Now with 100% less merge and rebase!

All the failures encountered by the autosync job were caused by merge conflicts created during a rebase. The default merge algorithm isn't equipped to handle what we're putting it through here (like regularly having 2 distinct, but nearly identical commits on separate branches). It even sometimes managed to create conflicts on files that were unchanged in the incoming changes. 😲 So, this PR removes rebasing all together.

---
In the event that commits were made on the base branch that are not present on the autosync branch, reset the autosync branch to the base branch. This discards any commits on the PR branch, fast forwards to the head of the base branch, and finally creates a new commit adding the current overrides.

In theory, this should _never_ cause conflicts again.